### PR TITLE
Use upload-artifacts v4.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
        run: make
      
      - name: Upload artifact
-       uses: actions/upload-artifact@v3
+       uses: actions/upload-artifact@v4
        with:
         name: MuffinStoreJailed
         path: MuffinStoreJailed.ipa


### PR DESCRIPTION
upload-artificats v1-v3 are scheduled for deprecation. Soon the build processes will stop working.